### PR TITLE
Fix Gateway Pre-Filter to Ignore Requests to /oauth and to Be More Clear About What service(s) It is Using

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,8 @@
     <name>SMART COSMOS Gateway</name>
     <description>SMART COSMOS Gateway based on the Netflix OSS Zuul Server</description>
     <properties>
-        <start-class>net.smartcosmos.cluster.gateway.GatewayApplication</start-class>
         <smartcosmos-framework.version>3.0.0-SNAPSHOT</smartcosmos-framework.version>
+        <start-class>net.smartcosmos.cluster.gateway.GatewayApplication</start-class>
     </properties>
     <dependencies>
         <dependency>

--- a/src/main/java/net/smartcosmos/cluster/gateway/config/AuthenticationServerConnectionProperties.java
+++ b/src/main/java/net/smartcosmos/cluster/gateway/config/AuthenticationServerConnectionProperties.java
@@ -1,0 +1,22 @@
+package net.smartcosmos.cluster.gateway.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Properties read from the configuration files to connect to the authentication server.
+ */
+@Data
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+@ConfigurationProperties("smartcosmos.security.resource.authorization-server")
+public class AuthenticationServerConnectionProperties {
+    private String locationUri = "http://smartcosmos-auth-server";
+    private String name = "smartcosmosclient";
+    private String password = "LkRv4Z-=caBcx.zX";
+}

--- a/src/main/java/net/smartcosmos/cluster/gateway/config/GatewayConfiguration.java
+++ b/src/main/java/net/smartcosmos/cluster/gateway/config/GatewayConfiguration.java
@@ -1,7 +1,5 @@
 package net.smartcosmos.cluster.gateway.config;
 
-import java.security.KeyPair;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.netflix.ribbon.RibbonClientHttpRequestFactory;
@@ -13,25 +11,18 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.config.annotation.authentication.configurers.GlobalAuthenticationConfigurerAdapter;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.oauth2.provider.token.DefaultAccessTokenConverter;
-import org.springframework.security.oauth2.provider.token.store.JwtAccessTokenConverter;
-import org.springframework.security.oauth2.provider.token.store.KeyStoreKeyFactory;
-import org.springframework.util.Assert;
-
-import net.smartcosmos.security.SecurityResourceProperties;
-import net.smartcosmos.security.user.SmartCosmosUserAuthenticationConverter;
 
 /**
  * Configuration class for Gateway.
  */
 @Configuration
 @EnableGlobalAuthentication
-@EnableConfigurationProperties({ SecurityResourceProperties.class })
+@EnableConfigurationProperties({ AuthenticationServerConnectionProperties.class })
 @Profile("!test")
 public class GatewayConfiguration extends GlobalAuthenticationConfigurerAdapter {
 
     @Autowired
-    private SecurityResourceProperties securityResourceProperties;
+    private AuthenticationServerConnectionProperties securityResourceProperties;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -42,23 +33,4 @@ public class GatewayConfiguration extends GlobalAuthenticationConfigurerAdapter 
     public RibbonClientHttpRequestFactory ribbonClientHttpRequestFactory(SpringClientFactory clientFactory) {
         return new RibbonClientHttpRequestFactory(clientFactory);
     }
-
-    @Bean
-    public JwtAccessTokenConverter jwtAccessTokenConverter() {
-
-        Assert.hasText(securityResourceProperties.getKeystore().getKeypair());
-        Assert.notNull(securityResourceProperties.getKeystore().getLocation());
-
-        JwtAccessTokenConverter converter = new JwtAccessTokenConverter();
-        ((DefaultAccessTokenConverter) converter.getAccessTokenConverter()).setUserTokenConverter(new SmartCosmosUserAuthenticationConverter());
-        KeyPair keyPair = new KeyStoreKeyFactory(
-            securityResourceProperties.getKeystore().getLocation(),
-            securityResourceProperties.getKeystore().getPassword()).getKeyPair(
-            securityResourceProperties.getKeystore().getKeypair(),
-            securityResourceProperties.getKeystore()
-                .getKeypairPassword());
-        converter.setKeyPair(keyPair);
-        return converter;
-    }
-
 }

--- a/src/main/java/net/smartcosmos/cluster/gateway/filters/PreAuthorizationFilter.java
+++ b/src/main/java/net/smartcosmos/cluster/gateway/filters/PreAuthorizationFilter.java
@@ -53,16 +53,16 @@ public class PreAuthorizationFilter extends ZuulFilter {
 
     @Override
     public boolean shouldFilter() {
-        return isNotAuthorizationPath() &&isBasicAuthRequest();
+        return !isAuthorizationPath() && isBasicAuthRequest();
     }
 
     public boolean isBasicAuthRequest() {
         return StringUtils.startsWith(HTTPRequestUtils.getInstance().getHeaderValue(HttpHeaders.AUTHORIZATION), BASIC_AUTHENTICATION_TYPE);
     }
 
-    public boolean isNotAuthorizationPath() {
+    public boolean isAuthorizationPath() {
         String path = RequestContext.getCurrentContext().getRequest().getRequestURI();
-        return (StringUtils.startsWith(path, REQUEST_PATH_OAUTH) || StringUtils.startsWith(path, "/" + REQUEST_PATH_OAUTH));
+        return StringUtils.startsWith(path, REQUEST_PATH_OAUTH) || StringUtils.startsWith(path, "/" + REQUEST_PATH_OAUTH);
     }
 
     private HttpServletRequest getRequest() {

--- a/src/main/java/net/smartcosmos/cluster/gateway/filters/PreAuthorizationFilter.java
+++ b/src/main/java/net/smartcosmos/cluster/gateway/filters/PreAuthorizationFilter.java
@@ -28,10 +28,10 @@ import net.smartcosmos.cluster.gateway.AuthenticationClient;
 @Service
 public class PreAuthorizationFilter extends ZuulFilter {
 
-    public static final String FILTER_TYPE_PRE = "pre";
-    public static final String BASIC_AUTHENTICATION_TYPE = "Basic";
+    private static final String FILTER_TYPE_PRE = "pre";
+    private static final String BASIC_AUTHENTICATION_TYPE = "Basic";
+    private static final String REQUEST_PATH_OAUTH = "oauth";
 
-    //    private final AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource = new WebAuthenticationDetailsSource();
     private Map<String, ProxyAuthenticationProperties.Route> routes = new HashMap<>();
     private final AuthenticationClient authenticationClient;
 
@@ -53,11 +53,16 @@ public class PreAuthorizationFilter extends ZuulFilter {
 
     @Override
     public boolean shouldFilter() {
-        return isBasicAuthRequest();
+        return isNotAuthorizationPath() &&isBasicAuthRequest();
     }
 
-    private boolean isBasicAuthRequest() {
+    public boolean isBasicAuthRequest() {
         return StringUtils.startsWith(HTTPRequestUtils.getInstance().getHeaderValue(HttpHeaders.AUTHORIZATION), BASIC_AUTHENTICATION_TYPE);
+    }
+
+    public boolean isNotAuthorizationPath() {
+        String path = RequestContext.getCurrentContext().getRequest().getRequestURI();
+        return (StringUtils.startsWith(path, REQUEST_PATH_OAUTH) || StringUtils.startsWith(path, "/" + REQUEST_PATH_OAUTH));
     }
 
     private HttpServletRequest getRequest() {


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Changed properties loaded to use sensible names and locally declared properties file
- added ability to ignore requests to `/oauth/**` so an OAuth token is not fetched when trying to create an OAuth token

### How is this patch documented?

Javadoc

### How was this patch tested?

Unit tests and Postman scripts

#### Depends On

https://github.com/SMARTRACTECHNOLOGY/smartcosmos-cluster-config/pull/15