### PR TITLE
OBJECTS-977: Add an ErrorController for Incorrect 200 Responses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,10 @@
             <artifactId>smartcosmos-framework</artifactId>
         </dependency>
         <dependency>
+            <groupId>net.smartcosmos</groupId>
+            <artifactId>smartcosmos-framework-test</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-undertow</artifactId>
         </dependency>

--- a/src/main/java/net/smartcosmos/cluster/gateway/config/GatewayConfiguration.java
+++ b/src/main/java/net/smartcosmos/cluster/gateway/config/GatewayConfiguration.java
@@ -1,6 +1,8 @@
 package net.smartcosmos.cluster.gateway.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.embedded.undertow.UndertowDeploymentInfoCustomizer;
+import org.springframework.boot.context.embedded.undertow.UndertowEmbeddedServletContainerFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.netflix.ribbon.RibbonClientHttpRequestFactory;
 import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
@@ -26,11 +28,21 @@ public class GatewayConfiguration extends GlobalAuthenticationConfigurerAdapter 
 
     @Bean
     public PasswordEncoder passwordEncoder() {
+
         return new BCryptPasswordEncoder();
     }
 
     @Bean
     public RibbonClientHttpRequestFactory ribbonClientHttpRequestFactory(SpringClientFactory clientFactory) {
+
         return new RibbonClientHttpRequestFactory(clientFactory);
+    }
+
+    @Bean
+    public UndertowEmbeddedServletContainerFactory embeddedServletContainerFactory() {
+
+        UndertowEmbeddedServletContainerFactory factory = new UndertowEmbeddedServletContainerFactory();
+        factory.addDeploymentInfoCustomizers((UndertowDeploymentInfoCustomizer) deploymentInfo -> deploymentInfo.setAllowNonStandardWrappers(true));
+        return factory;
     }
 }

--- a/src/main/java/net/smartcosmos/cluster/gateway/config/GatewayConfiguration.java
+++ b/src/main/java/net/smartcosmos/cluster/gateway/config/GatewayConfiguration.java
@@ -38,6 +38,12 @@ public class GatewayConfiguration extends GlobalAuthenticationConfigurerAdapter 
         return new RibbonClientHttpRequestFactory(clientFactory);
     }
 
+    /**
+     * Need to configure Undertow to allo non standard wrappers or the exception gets lost in the noice.  This way the
+     * exception will bubble out to the custom error controller.
+     *
+     * @return a modified Undertow config factory
+     */
     @Bean
     public UndertowEmbeddedServletContainerFactory embeddedServletContainerFactory() {
 

--- a/src/main/java/net/smartcosmos/cluster/gateway/resource/GatewayErrorController.java
+++ b/src/main/java/net/smartcosmos/cluster/gateway/resource/GatewayErrorController.java
@@ -1,0 +1,37 @@
+package net.smartcosmos.cluster.gateway.resource;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.boot.autoconfigure.web.ErrorController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+/**
+ *
+ */
+@Slf4j
+@RestController
+@ResponseBody
+@PreAuthorize("permitAll()")
+public class GatewayErrorController implements ErrorController {
+
+    public static final String ERROR_PATH = "/error";
+
+    @RequestMapping(value = ERROR_PATH)
+    public ResponseEntity<?> error() {
+
+        return ResponseEntity.status(INTERNAL_SERVER_ERROR)
+            .build();
+    }
+
+    @Override
+    public String getErrorPath() {
+
+        return ERROR_PATH;
+    }
+}

--- a/src/main/java/net/smartcosmos/cluster/gateway/resource/GatewayErrorController.java
+++ b/src/main/java/net/smartcosmos/cluster/gateway/resource/GatewayErrorController.java
@@ -27,6 +27,7 @@ public class GatewayErrorController implements ErrorController {
     public static final String ATTR_ERROR_EXCEPTION = "error.exception";
     public static final String ATTR_ERROR_MESSAGE = "error.message";
     public static final String ATTR_ERROR_STATUS_CODE = "error.status_code";
+    public static final String ZUUL_REQUEST_URI = "requestURI";
 
     @RequestMapping(value = ERROR_PATH)
     public ResponseEntity<?> error() {
@@ -35,8 +36,8 @@ public class GatewayErrorController implements ErrorController {
             RequestContext ctx = RequestContext.getCurrentContext();
             HttpServletRequest request = ctx.getRequest();
             String requestUri = "unknown-uri";
-            if (request != null && request.getRequestURI() != null) {
-                requestUri = request.getRequestURI();
+            if (ctx != null && ctx.get(ZUUL_REQUEST_URI) != null) {
+                requestUri = (String) ctx.get(ZUUL_REQUEST_URI);
             }
 
             String statusCodeString = "Unknown";
@@ -56,7 +57,7 @@ public class GatewayErrorController implements ErrorController {
             }
 
             String errorMessage = "No message available";
-            if (ctx.containsKey(ATTR_ERROR_MESSAGE)) {
+            if (ctx != null && ctx.containsKey(ATTR_ERROR_MESSAGE)) {
                 errorMessage = (String) ctx.get(ATTR_ERROR_MESSAGE);
             }
 

--- a/src/main/java/net/smartcosmos/cluster/gateway/resource/GatewayErrorController.java
+++ b/src/main/java/net/smartcosmos/cluster/gateway/resource/GatewayErrorController.java
@@ -1,5 +1,8 @@
 package net.smartcosmos.cluster.gateway.resource;
 
+import javax.servlet.http.HttpServletRequest;
+
+import com.netflix.zuul.context.RequestContext;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.boot.autoconfigure.web.ErrorController;
@@ -20,13 +23,38 @@ import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 @PreAuthorize("permitAll()")
 public class GatewayErrorController implements ErrorController {
 
-    public static final String ERROR_PATH = "/error";
+    private static final String ERROR_PATH = "/error";
+    private static final String ATTR_ERROR_EXCEPTION = "error.exception";
+    public static final String ATTR_ERROR_MESSAGE = "error.message";
+    public static final String ATTR_JAVAX_SERVLET_ERROR_STATUS_CODE = "javax.servlet.error.status_code";
+    public static final String ATTR_JAVAX_SERVLET_ERROR_MESSAGE = "javax.servlet.error.message";
+    public static final String ATTR_ERROR_STATUS_CODE = "error.status_code";
 
     @RequestMapping(value = ERROR_PATH)
     public ResponseEntity<?> error() {
 
-        return ResponseEntity.status(INTERNAL_SERVER_ERROR)
-            .build();
+        try {
+            RequestContext ctx = RequestContext.getCurrentContext();
+            HttpServletRequest request = ctx.getRequest();
+
+            int statusCode = (Integer) ctx.get(ATTR_ERROR_STATUS_CODE);
+
+            if (ctx.containsKey(ATTR_ERROR_EXCEPTION)) {
+                Object errorException = ctx.get(ATTR_ERROR_EXCEPTION);
+            }
+
+            if (ctx.containsKey(ATTR_ERROR_MESSAGE)) {
+                String message = (String) ctx.get(ATTR_ERROR_MESSAGE);
+                request.setAttribute(ATTR_JAVAX_SERVLET_ERROR_MESSAGE, message);
+            }
+
+            return ResponseEntity.status(INTERNAL_SERVER_ERROR)
+                .build();
+        } catch (Throwable t) {
+            log.info("Exception, cause: {}", t.toString());
+            return ResponseEntity.status(INTERNAL_SERVER_ERROR)
+                .body(t.toString());
+        }
     }
 
     @Override

--- a/src/test/java/net/smartcosmos/cluster/gateway/resource/GatewayErrorControllerTest.java
+++ b/src/test/java/net/smartcosmos/cluster/gateway/resource/GatewayErrorControllerTest.java
@@ -1,0 +1,204 @@
+package net.smartcosmos.cluster.gateway.resource;
+
+import javax.servlet.DispatcherType;
+import javax.servlet.ServletContext;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
+import com.netflix.zuul.context.RequestContext;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.mockito.*;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.RequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.WebApplicationContext;
+
+import net.smartcosmos.cluster.gateway.GatewayApplication;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static net.smartcosmos.cluster.gateway.resource.GatewayErrorController.ATTR_ERROR_EXCEPTION;
+import static net.smartcosmos.cluster.gateway.resource.GatewayErrorController.ATTR_ERROR_MESSAGE;
+import static net.smartcosmos.cluster.gateway.resource.GatewayErrorController.ATTR_ERROR_STATUS_CODE;
+
+/**
+ * Test the error controller.
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = { GatewayApplication.class, GatewayErrorControllerTest.TestConfiguration.class })
+@WebAppConfiguration
+@ActiveProfiles("test")
+@IntegrationTest({ "spring.cloud.config.enabled=false", "eureka.client.enabled:false" })
+public class GatewayErrorControllerTest {
+
+    public static final String URL_INTERNAL_SERVER_ERROR = "/internalServerError";
+    public static final int EXPECTED_HTTP_STATUS_CODE = HttpStatus.INTERNAL_SERVER_ERROR.value();
+    MockMvc mockMvc;
+
+    @Autowired
+    WebApplicationContext webApplicationContext;
+
+    @Captor
+    ArgumentCaptor argumentCaptor;
+
+    @Before
+    public void setUp() throws Exception {
+
+        MockitoAnnotations.initMocks(this);
+
+        this.mockMvc = MockMvcBuilders
+            .webAppContextSetup(webApplicationContext)
+            .build();
+    }
+
+    /**
+     * Test that logging happens.  A merging of the ideas from
+     * - https://dzone.com/articles/unit-testing-asserting-line
+     * - http://bloodredsun.com/2010/12/09/checking-logging-in-unit-tests/
+     *
+     * @throws Exception
+     */
+    @Test
+    public void thatErrorHandlesNoExceptionInTheContext() throws Exception {
+
+        int EXPECTED_HTTP_STATUS_CODE = HttpStatus.INTERNAL_SERVER_ERROR.value();
+        String EXPECTED_MSG_TESTING_EXCEPTION_FOUND = "Testing exception found!";
+
+        //Zuul RequestContext
+        RequestContext.getCurrentContext().set(ATTR_ERROR_STATUS_CODE, HttpStatus.INTERNAL_SERVER_ERROR.value());
+        RequestContext.getCurrentContext().set(ATTR_ERROR_MESSAGE, EXPECTED_MSG_TESTING_EXCEPTION_FOUND);
+
+        Logger root = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        Appender mockAppender = mock(Appender.class);
+        when(mockAppender.getName()).thenReturn("MOCK");
+        root.addAppender(mockAppender);
+
+        MvcResult response = mockMvc.perform(MockMvcRequestBuilders.get(GatewayErrorController.ERROR_PATH))
+            .andReturn();
+
+        verify(mockAppender).doAppend(argumentCaptor.capture());
+        LoggingEvent loggingEvent = (LoggingEvent) argumentCaptor.getValue();
+        assertThat(loggingEvent.getLevel(), CoreMatchers.is(Level.WARN));
+        assertThat(loggingEvent.getMessage(), containsString("exception was encountered processing"));
+        assertThat(loggingEvent.getMessage(), containsString("cause: 'No exception in context'"));
+        assertThat(loggingEvent.getMessage(), containsString("statusCode: '" + EXPECTED_HTTP_STATUS_CODE + "'"));
+        assertThat(loggingEvent.getMessage(), containsString("message: '" + EXPECTED_MSG_TESTING_EXCEPTION_FOUND + "'"));
+    }
+
+    @Test
+    public void thatErrorHandlesNoMessageInTheContext() throws Exception {
+
+    }
+
+    /**
+     * Test that logging happens.  A merging of the ideas from
+     * - https://dzone.com/articles/unit-testing-asserting-line
+     * - http://bloodredsun.com/2010/12/09/checking-logging-in-unit-tests/
+     *
+     * @throws Exception
+     */
+    @Test
+    public void thatErrorIsHandledWithMessageAndException() throws Exception {
+
+        int EXPECTED_HTTP_STATUS_CODE = HttpStatus.INTERNAL_SERVER_ERROR.value();
+        String EXPECTED_MSG_TESTING_EXCEPTION_FOUND = "Testing exception found!";
+        Exception EXPECTED_EXCEPTION = new InternalServerErrorException(EXPECTED_MSG_TESTING_EXCEPTION_FOUND);
+
+        //Zuul RequestContext
+        RequestContext.getCurrentContext().set(ATTR_ERROR_STATUS_CODE, HttpStatus.INTERNAL_SERVER_ERROR.value());
+        RequestContext.getCurrentContext().set(ATTR_ERROR_EXCEPTION, EXPECTED_EXCEPTION);
+        RequestContext.getCurrentContext().set(ATTR_ERROR_MESSAGE, EXPECTED_MSG_TESTING_EXCEPTION_FOUND);
+
+        Logger root = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        Appender mockAppender = mock(Appender.class);
+        when(mockAppender.getName()).thenReturn("MOCK");
+        root.addAppender(mockAppender);
+
+        MvcResult response = mockMvc.perform(MockMvcRequestBuilders.get(GatewayErrorController.ERROR_PATH))
+            .andReturn();
+
+        verify(mockAppender).doAppend(argumentCaptor.capture());
+        LoggingEvent loggingEvent = (LoggingEvent) argumentCaptor.getValue();
+        assertThat(loggingEvent.getLevel(), CoreMatchers.is(Level.WARN));
+        assertThat(loggingEvent.getMessage(), containsString("exception was encountered processing"));
+        assertThat(loggingEvent.getMessage(), containsString("message: '" + EXPECTED_MSG_TESTING_EXCEPTION_FOUND + "'"));
+        assertThat(loggingEvent.getMessage(), containsString("statusCode: '" + EXPECTED_HTTP_STATUS_CODE + "'"));
+        assertThat(loggingEvent.getMessage(),
+                   containsString("cause: '" + InternalServerErrorException.class.getName() + ": " + EXPECTED_MSG_TESTING_EXCEPTION_FOUND + "'"));
+    }
+
+    @Test
+    public void getErrorPath() throws Exception {
+
+    }
+
+    private class ErrorDispatcher implements RequestBuilder {
+
+        private MvcResult result;
+
+        private String path;
+
+        ErrorDispatcher(MvcResult result, String path) {
+
+            this.result = result;
+            this.path = path;
+        }
+
+        @Override
+        public MockHttpServletRequest buildRequest(ServletContext servletContext) {
+
+            MockHttpServletRequest request = this.result.getRequest();
+            request.setDispatcherType(DispatcherType.ERROR);
+            request.setRequestURI(this.path);
+            return request;
+        }
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    private static class InternalServerErrorException extends RuntimeException {
+
+        InternalServerErrorException(String string) {
+
+            super(string);
+        }
+
+    }
+
+    @Configuration
+    public static class TestConfiguration {
+
+        @RestController
+        protected static class Errors {
+
+            @RequestMapping(URL_INTERNAL_SERVER_ERROR)
+            public String bang() {
+
+                throw new InternalServerErrorException("Expected");
+            }
+        }
+    }
+}

--- a/src/test/resources/bootstrap.yml
+++ b/src/test/resources/bootstrap.yml
@@ -1,0 +1,8 @@
+project:
+  artifactId: smartcosmos-gateway
+spring:
+  application:
+    name: smartcosmos-gateway
+  cloud:
+    config:
+      enabled: false


### PR DESCRIPTION
### What changes were proposed in this pull request?

By default the gateway returns a 200 for all errors from routing problems.  Add an error controller to return the Zuul exception.

### How is this patch documented?

In the code

### How was this patch tested?

Unit tests and Postman tests

#### Depends On

nothing