### PR TITLE
Enhancement/objects 1050

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -4,7 +4,7 @@
 
 === New Features
 
-No new features are added in this release.
+* Authentication failures in the `PreAuthorizationFilter` abort the request routing and return an *Unauthorized* error response instead
 
 === Bugfixes & Improvements
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,6 +10,7 @@ No new features are added in this release.
 
 * PROFILES-667: add zipkin starter for distributed tracing
 * PROFILES-740: Gateway service logs passwords in clear text
+* OBJECTS-1050: Change Gateway Authentication Client RestTemplate to Bean
 
 == Release 3.0.0 (August 12, 2016)
 

--- a/src/main/java/net/smartcosmos/cluster/gateway/AuthenticationClientDefault.java
+++ b/src/main/java/net/smartcosmos/cluster/gateway/AuthenticationClientDefault.java
@@ -1,28 +1,15 @@
 package net.smartcosmos.cluster.gateway;
 
-import java.io.IOException;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.util.Collections;
-import java.util.List;
-import javax.annotation.PostConstruct;
 
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.cloud.netflix.ribbon.RibbonClientHttpRequestFactory;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpRequest;
-import org.springframework.http.client.ClientHttpRequestExecution;
-import org.springframework.http.client.ClientHttpRequestInterceptor;
-import org.springframework.http.client.ClientHttpResponse;
-import org.springframework.http.client.InterceptingClientHttpRequestFactory;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.stereotype.Service;
-import org.springframework.util.Base64Utils;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -36,61 +23,29 @@ import net.smartcosmos.cluster.gateway.config.AuthenticationServerConnectionProp
 @EnableConfigurationProperties({ AuthenticationServerConnectionProperties.class })
 public class AuthenticationClientDefault implements AuthenticationClient {
 
-    private final RibbonClientHttpRequestFactory ribbonClientHttpRequestFactory;
     private final AuthenticationServerConnectionProperties authServerConnectionProperties;
     private RestTemplate authServerRestTemplate;
 
     @Autowired
     public AuthenticationClientDefault(
-        RibbonClientHttpRequestFactory ribbonClientHttpRequestFactory,
+        @Qualifier("authServerRestTemplate") RestTemplate authServerRestTemplate,
         AuthenticationServerConnectionProperties authServerConnectionProperties) {
-        this.ribbonClientHttpRequestFactory = ribbonClientHttpRequestFactory;
+
+        this.authServerRestTemplate = authServerRestTemplate;
         this.authServerConnectionProperties = authServerConnectionProperties;
     }
 
-    @PostConstruct
-    public void init() {
-        List<ClientHttpRequestInterceptor> interceptors = Collections.<ClientHttpRequestInterceptor>singletonList(
-            new BasicAuthorizationInterceptor(authServerConnectionProperties.getName(),
-                                              authServerConnectionProperties.getPassword()));
-        authServerRestTemplate = new RestTemplate(new InterceptingClientHttpRequestFactory(ribbonClientHttpRequestFactory, interceptors));
-    }
-
     @Override
-    public OAuth2AccessToken getOauthToken(String username, String password)
-        throws InternalAuthenticationServiceException {
-            URI uri = UriComponentsBuilder.fromHttpUrl(authServerConnectionProperties.getLocationUri())
-                .pathSegment(PATH_OAUTH_TOKEN_REQUEST)
-                .queryParam(PARAM_GRANT_TYPE, GRANT_TYPE_PASSWORD)
-                .queryParam(PARAM_USERNAME, username)
-                .queryParam(PARAM_PASSWORD, password)
-                .build().toUri();
-            log.debug("Connecting to {} using username: {} to authenticate user.", uri, username);
-            return authServerRestTemplate.exchange(uri,
-                                                   HttpMethod.POST,
-                                                   null,
-                                                   OAuth2AccessToken.class)
-                .getBody();
+    public OAuth2AccessToken getOauthToken(String username, String password) throws InternalAuthenticationServiceException {
+
+        URI uri = UriComponentsBuilder.fromHttpUrl(authServerConnectionProperties.getLocationUri())
+            .pathSegment(PATH_OAUTH_TOKEN_REQUEST)
+            .queryParam(PARAM_GRANT_TYPE, GRANT_TYPE_PASSWORD)
+            .queryParam(PARAM_USERNAME, username)
+            .queryParam(PARAM_PASSWORD, password)
+            .build()
+            .toUri();
+        log.debug("Connecting to {} using username: {} to authenticate user.", uri, username);
+        return authServerRestTemplate.postForObject(uri, null, OAuth2AccessToken.class);
     }
-
-    private static class BasicAuthorizationInterceptor implements ClientHttpRequestInterceptor {
-        private static final String BASIC_AUTHENTICATION_HEADER = "Basic ";
-        private final String username;
-        private final String password;
-
-        BasicAuthorizationInterceptor(String username, String password) {
-            this.username = username;
-            this.password = (password == null ? "" : password);
-        }
-
-        @Override
-        public ClientHttpResponse intercept(
-            HttpRequest request, byte[] body,
-            ClientHttpRequestExecution execution) throws IOException {
-            String token = Base64Utils.encodeToString((this.username + ":" + this.password).getBytes(StandardCharsets.UTF_8));
-            request.getHeaders().add(HttpHeaders.AUTHORIZATION, BASIC_AUTHENTICATION_HEADER + token);
-            return execution.execute(request, body);
-        }
-    }
-
 }

--- a/src/main/java/net/smartcosmos/cluster/gateway/AuthenticationClientDefault.java
+++ b/src/main/java/net/smartcosmos/cluster/gateway/AuthenticationClientDefault.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
@@ -35,7 +36,7 @@ public class AuthenticationClientDefault implements AuthenticationClient {
     }
 
     @Override
-    public OAuth2AccessToken getOauthToken(String username, String password) throws InternalAuthenticationServiceException {
+    public OAuth2AccessToken getOauthToken(String username, String password) throws AuthenticationException {
 
         String authServerUri = authServerConnectionProperties.getLocationUri();
         String uriString = UriComponentsBuilder.fromHttpUrl(authServerUri)

--- a/src/main/java/net/smartcosmos/cluster/gateway/AuthenticationClientDefault.java
+++ b/src/main/java/net/smartcosmos/cluster/gateway/AuthenticationClientDefault.java
@@ -1,7 +1,5 @@
 package net.smartcosmos.cluster.gateway;
 
-import java.net.URI;
-
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,22 +37,22 @@ public class AuthenticationClientDefault implements AuthenticationClient {
     @Override
     public OAuth2AccessToken getOauthToken(String username, String password) throws InternalAuthenticationServiceException {
 
-        URI uri = UriComponentsBuilder.fromHttpUrl(authServerConnectionProperties.getLocationUri())
+        String authServerUri = authServerConnectionProperties.getLocationUri();
+        String uriString = UriComponentsBuilder.fromHttpUrl(authServerUri)
             .pathSegment(PATH_OAUTH_TOKEN_REQUEST)
             .queryParam(PARAM_GRANT_TYPE, GRANT_TYPE_PASSWORD)
             .queryParam(PARAM_USERNAME, username)
             .queryParam(PARAM_PASSWORD, password)
             .build()
-            .toUri();
-        log.debug("Connecting to {} using username: {} to authenticate user.", uri, username);
+            .toUriString();
+        log.debug("Connecting to {} using username: {} to authenticate user.", authServerUri, username);
 
         try {
-            return authServerRestTemplate.postForObject(uri, null, OAuth2AccessToken.class);
+            return authServerRestTemplate.postForObject(uriString, null, OAuth2AccessToken.class);
         } catch (RestClientException e) {
             String message = String.format("Authenticating user %s with request %s failed: %s",
                                            username,
-                                           uri.toString()
-                                               .replace(password, "[PROTECTED]"),
+                                           uriString.replace(PARAM_PASSWORD + "=" + password, PARAM_PASSWORD + "=[PROTECTED]"),
                                            e.toString());
             log.warn(message);
             log.debug(message, e);

--- a/src/main/java/net/smartcosmos/cluster/gateway/config/GatewayConfiguration.java
+++ b/src/main/java/net/smartcosmos/cluster/gateway/config/GatewayConfiguration.java
@@ -27,6 +27,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.util.Base64Utils;
 import org.springframework.web.client.RestTemplate;
 
+import net.smartcosmos.cluster.gateway.rest.AuthenticationErrorHandler;
+
 /**
  * Configuration class for Gateway.
  */
@@ -69,12 +71,16 @@ public class GatewayConfiguration extends GlobalAuthenticationConfigurerAdapter 
     @Autowired
     public RestTemplate authServerRestTemplate(
         RibbonClientHttpRequestFactory ribbonClientHttpRequestFactory,
+        AuthenticationErrorHandler authenticationErrorHandler,
         AuthenticationServerConnectionProperties authServerConnectionProperties) {
 
         List<ClientHttpRequestInterceptor> interceptors = Collections.<ClientHttpRequestInterceptor>singletonList(
             new BasicAuthorizationInterceptor(authServerConnectionProperties.getName(),
                                               authServerConnectionProperties.getPassword()));
-        return new RestTemplate(new InterceptingClientHttpRequestFactory(ribbonClientHttpRequestFactory, interceptors));
+        RestTemplate restTemplate = new RestTemplate(new InterceptingClientHttpRequestFactory(ribbonClientHttpRequestFactory, interceptors));
+        restTemplate.setErrorHandler(authenticationErrorHandler);
+
+        return restTemplate;
     }
 
     private static class BasicAuthorizationInterceptor implements ClientHttpRequestInterceptor {

--- a/src/main/java/net/smartcosmos/cluster/gateway/config/GatewayConfiguration.java
+++ b/src/main/java/net/smartcosmos/cluster/gateway/config/GatewayConfiguration.java
@@ -1,5 +1,10 @@
 package net.smartcosmos.cluster.gateway.config;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.embedded.undertow.UndertowDeploymentInfoCustomizer;
 import org.springframework.boot.context.embedded.undertow.UndertowEmbeddedServletContainerFactory;
@@ -9,10 +14,18 @@ import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.client.InterceptingClientHttpRequestFactory;
 import org.springframework.security.config.annotation.authentication.configuration.EnableGlobalAuthentication;
 import org.springframework.security.config.annotation.authentication.configurers.GlobalAuthenticationConfigurerAdapter;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.util.Base64Utils;
+import org.springframework.web.client.RestTemplate;
 
 /**
  * Configuration class for Gateway.
@@ -39,7 +52,7 @@ public class GatewayConfiguration extends GlobalAuthenticationConfigurerAdapter 
     }
 
     /**
-     * Need to configure Undertow to allo non standard wrappers or the exception gets lost in the noice.  This way the
+     * Need to configure Undertow to allow non standard wrappers or the exception gets lost in the noice.  This way the
      * exception will bubble out to the custom error controller.
      *
      * @return a modified Undertow config factory
@@ -50,5 +63,41 @@ public class GatewayConfiguration extends GlobalAuthenticationConfigurerAdapter 
         UndertowEmbeddedServletContainerFactory factory = new UndertowEmbeddedServletContainerFactory();
         factory.addDeploymentInfoCustomizers((UndertowDeploymentInfoCustomizer) deploymentInfo -> deploymentInfo.setAllowNonStandardWrappers(true));
         return factory;
+    }
+
+    @Bean
+    @Autowired
+    public RestTemplate authServerRestTemplate(
+        RibbonClientHttpRequestFactory ribbonClientHttpRequestFactory,
+        AuthenticationServerConnectionProperties authServerConnectionProperties) {
+
+        List<ClientHttpRequestInterceptor> interceptors = Collections.<ClientHttpRequestInterceptor>singletonList(
+            new BasicAuthorizationInterceptor(authServerConnectionProperties.getName(),
+                                              authServerConnectionProperties.getPassword()));
+        return new RestTemplate(new InterceptingClientHttpRequestFactory(ribbonClientHttpRequestFactory, interceptors));
+    }
+
+    private static class BasicAuthorizationInterceptor implements ClientHttpRequestInterceptor {
+
+        private static final String BASIC_AUTHENTICATION_HEADER = "Basic ";
+        private final String username;
+        private final String password;
+
+        BasicAuthorizationInterceptor(String username, String password) {
+
+            this.username = username;
+            this.password = (password == null ? "" : password);
+        }
+
+        @Override
+        public ClientHttpResponse intercept(
+            HttpRequest request, byte[] body,
+            ClientHttpRequestExecution execution) throws IOException {
+
+            String token = Base64Utils.encodeToString((this.username + ":" + this.password).getBytes(StandardCharsets.UTF_8));
+            request.getHeaders()
+                .add(HttpHeaders.AUTHORIZATION, BASIC_AUTHENTICATION_HEADER + token);
+            return execution.execute(request, body);
+        }
     }
 }

--- a/src/main/java/net/smartcosmos/cluster/gateway/config/GatewayConfiguration.java
+++ b/src/main/java/net/smartcosmos/cluster/gateway/config/GatewayConfiguration.java
@@ -54,7 +54,7 @@ public class GatewayConfiguration extends GlobalAuthenticationConfigurerAdapter 
     }
 
     /**
-     * Need to configure Undertow to allow non standard wrappers or the exception gets lost in the noice.  This way the
+     * Need to configure Undertow to allow non standard wrappers or the exception gets lost in the noise.  This way the
      * exception will bubble out to the custom error controller.
      *
      * @return a modified Undertow config factory

--- a/src/main/java/net/smartcosmos/cluster/gateway/filters/PreAuthorizationFilter.java
+++ b/src/main/java/net/smartcosmos/cluster/gateway/filters/PreAuthorizationFilter.java
@@ -77,9 +77,7 @@ public class PreAuthorizationFilter extends ZuulFilter {
 
     public boolean isAuthorizationPath() {
 
-        String path = RequestContext.getCurrentContext()
-            .getRequest()
-            .getRequestURI();
+        String path = getRequest().getRequestURI();
         return StringUtils.startsWith(path, REQUEST_PATH_OAUTH) || StringUtils.startsWith(path, "/" + REQUEST_PATH_OAUTH);
     }
 
@@ -113,8 +111,7 @@ public class PreAuthorizationFilter extends ZuulFilter {
 
     protected String[] getAuthenticationCredentials() {
 
-        RequestContext ctx = RequestContext.getCurrentContext();
-        HttpServletRequest request = ctx.getRequest();
+        HttpServletRequest request = getRequest();
 
         String base64Credentials = request.getHeader(HttpHeaders.AUTHORIZATION)
             .substring(BASIC_AUTHENTICATION_TYPE.length())
@@ -124,7 +121,7 @@ public class PreAuthorizationFilter extends ZuulFilter {
         return decodedCredentials.split(":", 2);
     }
 
-    private void setErrorResponse(HttpStatus statusCode, String message) {
+    protected void setErrorResponse(HttpStatus statusCode, String message) {
 
         String body = String.format("{\"message\": \"%s\"}", message);
 

--- a/src/main/java/net/smartcosmos/cluster/gateway/rest/AuthenticationErrorHandler.java
+++ b/src/main/java/net/smartcosmos/cluster/gateway/rest/AuthenticationErrorHandler.java
@@ -1,0 +1,88 @@
+package net.smartcosmos.cluster.gateway.rest;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.stereotype.Component;
+import org.springframework.util.FileCopyUtils;
+import org.springframework.web.client.DefaultResponseErrorHandler;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+/**
+ * Error Handler component for requests to the Auth Server.
+ */
+@Component
+@Slf4j
+public class AuthenticationErrorHandler extends DefaultResponseErrorHandler {
+
+    private static final String JSON_ERROR_DESCRIPTION = "error_description";
+
+    /**
+     * <p>The error handler intercepts the default error handler and checks if the returned HTTP status code is <i>400 Bad Request</i>. This status
+     * code particularly indicates that the authentication failure was not caused by the client or services, but was caused by invalid credentials
+     * or other account-related issues (e.g. account disabled).</p>
+     * <p>The method attempts to read the error description from the response body.</p>
+     *
+     * @param response the response
+     * @throws BadCredentialsException if the HTTP status code was <i>400 Bad Request</i>
+     * @throws IOException             in case of I/O errors
+     */
+    @Override
+    public void handleError(ClientHttpResponse response) throws BadCredentialsException, IOException {
+
+        String responseBody = getResponseBody(response);
+
+        if (BAD_REQUEST.equals(response.getStatusCode())) {
+            throw new BadCredentialsException(getErrorDescriptionFromBody(responseBody));
+        }
+
+        super.handleError(response);
+    }
+
+    private String getResponseBody(ClientHttpResponse response) {
+
+        try {
+            InputStream responseBody = response.getBody();
+            if (responseBody != null) {
+                return new String(FileCopyUtils.copyToByteArray(responseBody));
+            }
+        } catch (IOException ex) {
+            // ignore
+        }
+        return "";
+    }
+
+    private String getErrorDescriptionFromBody(String body) {
+
+        log.debug("Attempt to read error description from response body '{}'", body);
+
+        if (StringUtils.isNotBlank(body)) {
+            String[] tokens = body.replace("{", "")
+                .replace("}", "")
+                .replace("\"", "")
+                .split(",");
+
+            if (0 < tokens.length) {
+                Map<String, String> jsonMap = new HashMap<>();
+                for (String token : tokens) {
+                    String[] keyValue = token.split(":");
+                    jsonMap.put(keyValue[0], keyValue[1]);
+                }
+
+                if (jsonMap.containsKey(JSON_ERROR_DESCRIPTION)) {
+                    return jsonMap.get(JSON_ERROR_DESCRIPTION);
+                }
+            }
+        }
+
+        return "Invalid username or password Fallback";
+    }
+}

--- a/src/test/java/net/smartcosmos/cluster/gateway/config/GatewayConfigurationTest.java
+++ b/src/test/java/net/smartcosmos/cluster/gateway/config/GatewayConfigurationTest.java
@@ -10,6 +10,9 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.provider.token.store.JwtAccessTokenConverter;
+import org.springframework.web.client.RestTemplate;
+
+import static org.mockito.Mockito.mock;
 
 /**
  *
@@ -33,5 +36,11 @@ public class GatewayConfigurationTest {
     @Bean
     public JwtAccessTokenConverter jwtAccessTokenConverter() {
         return new JwtAccessTokenConverter();
+    }
+
+    @Bean
+    public RestTemplate authServerRestTemplate() {
+
+        return mock(RestTemplate.class);
     }
 }

--- a/src/test/java/net/smartcosmos/cluster/gateway/filters/PreAuthorizationFilterTest.java
+++ b/src/test/java/net/smartcosmos/cluster/gateway/filters/PreAuthorizationFilterTest.java
@@ -11,17 +11,21 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cloud.security.oauth2.proxy.ProxyAuthenticationProperties;
+import org.springframework.security.authentication.BadCredentialsException;
 
 import net.smartcosmos.cluster.gateway.AuthenticationClient;
 
 import static ch.qos.logback.classic.Level.WARN;
 import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 @SuppressWarnings("unchecked")
 @RunWith(MockitoJUnitRunner.class)
@@ -87,6 +91,26 @@ public class PreAuthorizationFilterTest {
     }
 
     @Test
+    public void thatRunLogsWithWarnLevelInCaseOfBadCredentialsException() {
+
+        final String username = "someUser";
+        final String password = "someArbitraryTestingPassw0rd";
+
+        doReturn(new String[] { username, password }).when(filter)
+            .getAuthenticationCredentials();
+
+        when(authenticationClient.getOauthToken(eq(username), eq(password))).thenThrow(new BadCredentialsException("someException"));
+        doNothing().when(filter)
+            .setErrorResponse(any(), any());
+
+        filter.run();
+
+        verify(mockAppender, times(1)).doAppend(captorLoggingEvent.capture());
+        LoggingEvent loggingEvent = captorLoggingEvent.getValue();
+        assertEquals(WARN, loggingEvent.getLevel());
+    }
+
+    @Test
     public void thatRunLogsCorrectMessageInCaseOfException() {
 
         final String username = "someUser";
@@ -107,6 +131,28 @@ public class PreAuthorizationFilterTest {
     }
 
     @Test
+    public void thatRunLogsCorrectMessageInCaseOfBadCredentialsException() {
+
+        final String username = "someUser";
+        final String password = "someArbitraryTestingPassw0rd";
+
+        doReturn(new String[] { username, password }).when(filter)
+            .getAuthenticationCredentials();
+
+        when(authenticationClient.getOauthToken(eq(username), eq(password))).thenThrow(new BadCredentialsException("someException"));
+        doNothing().when(filter)
+            .setErrorResponse(any(), any());
+
+        filter.run();
+
+        verify(mockAppender, times(1)).doAppend(captorLoggingEvent.capture());
+        LoggingEvent loggingEvent = captorLoggingEvent.getValue();
+        assertNotNull(loggingEvent.getMessage());
+        assertTrue(loggingEvent.getMessage()
+                       .startsWith("Authentication request failed."));
+    }
+
+    @Test
     public void thatRunLogsNoPasswordInCaseOfException() {
 
         final String username = "someUser";
@@ -116,6 +162,27 @@ public class PreAuthorizationFilterTest {
             .getAuthenticationCredentials();
 
         when(authenticationClient.getOauthToken(eq(username), eq(password))).thenThrow(new RuntimeException("someException"));
+
+        filter.run();
+
+        verify(mockAppender, times(1)).doAppend(captorLoggingEvent.capture());
+        LoggingEvent loggingEvent = captorLoggingEvent.getValue();
+        assertFalse(loggingEvent.getFormattedMessage()
+                        .contains(password));
+    }
+
+    @Test
+    public void thatRunLogsNoPasswordInCaseOfBadCredentialsException() {
+
+        final String username = "someUser";
+        final String password = "someArbitraryTestingPassw0rd";
+
+        doReturn(new String[] { username, password }).when(filter)
+            .getAuthenticationCredentials();
+
+        when(authenticationClient.getOauthToken(eq(username), eq(password))).thenThrow(new BadCredentialsException("someException"));
+        doNothing().when(filter)
+            .setErrorResponse(any(), any());
 
         filter.run();
 
@@ -185,4 +252,24 @@ public class PreAuthorizationFilterTest {
         assertTrue(loggingEvent.getFormattedMessage()
                        .contains(exception.toString()));
     }
+
+    @Test
+    public void thatRunCallsSetErrorResponseInCaseOfBadCredentialsException() {
+
+        final String username = "someUser";
+        final String password = "someArbitraryTestingPassw0rd";
+        final String message = "exception message";
+
+        doReturn(new String[] { username, password }).when(filter)
+            .getAuthenticationCredentials();
+
+        when(authenticationClient.getOauthToken(eq(username), eq(password))).thenThrow(new BadCredentialsException(message));
+        doNothing().when(filter)
+            .setErrorResponse(any(), any());
+
+        filter.run();
+
+        verify(filter, times(1)).setErrorResponse(eq(UNAUTHORIZED), eq(message));
+    }
+
 }

--- a/src/test/java/net/smartcosmos/cluster/gateway/rest/AuthenticationErrorHandlerTest.java
+++ b/src/test/java/net/smartcosmos/cluster/gateway/rest/AuthenticationErrorHandlerTest.java
@@ -1,0 +1,165 @@
+package net.smartcosmos.cluster.gateway.rest;
+
+import java.io.IOException;
+
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.mockito.*;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.web.client.DefaultResponseErrorHandler;
+import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.RestClientException;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AuthenticationErrorHandlerTest {
+
+    @Spy
+    private final AuthenticationErrorHandler errorHandler = new AuthenticationErrorHandler();
+
+    @Mock
+    ClientHttpResponse response;
+
+    @Before
+    public void setUp() throws IOException {
+
+        when(response.getStatusCode()).thenReturn(HttpStatus.INTERNAL_SERVER_ERROR);
+        when(response.getStatusText()).thenReturn(HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase());
+        when(response.getHeaders()).thenReturn(mock(HttpHeaders.class));
+    }
+
+    @After
+    public void tearDown() {
+
+        reset(response, errorHandler);
+    }
+
+    // region hasError()
+
+    @Test
+    public void thatHasErrorReturnsTrueInCaseOfBadRequest() throws Exception {
+
+        when(response.getStatusCode()).thenReturn(HttpStatus.BAD_REQUEST);
+
+        assertTrue(errorHandler.hasError(response));
+    }
+
+    @Test
+    public void thatHasErrorReturnsFalseInCaseOfOk() throws Exception {
+
+        when(response.getStatusCode()).thenReturn(HttpStatus.OK);
+
+        assertFalse(errorHandler.hasError(response));
+    }
+
+    @Test
+    public void thatHasErrorRespondsLikeBaseClass() throws Exception {
+
+        final ResponseErrorHandler baseErrorHandler = new DefaultResponseErrorHandler();
+
+        Boolean expectedResult = baseErrorHandler.hasError(response);
+        Boolean result = errorHandler.hasError(response);
+
+        assertNotNull(expectedResult);
+        assertNotNull(result);
+        assertEquals(expectedResult, result);
+    }
+
+    // endregion
+
+    // region handleError()
+
+    @Test(expected = BadCredentialsException.class)
+    public void thatHandleErrorThrowsBadCredentialsExceptionInCaseOfBadRequest() throws Exception {
+
+        when(response.getStatusCode()).thenReturn(HttpStatus.BAD_REQUEST);
+
+        errorHandler.handleError(response);
+    }
+
+    @Test
+    public void thatHandleErrorThrowsExceptionLikeBaseClass() throws Exception {
+
+        final ResponseErrorHandler baseErrorHandler = new DefaultResponseErrorHandler();
+
+        Exception expectedException = null;
+        Exception exception = null;
+
+        try {
+            baseErrorHandler.handleError(response);
+        } catch (RestClientException e) {
+            expectedException = e;
+        }
+
+        try {
+            errorHandler.handleError(response);
+        } catch (RestClientException e) {
+            exception = e;
+        }
+
+        assertNotNull(expectedException);
+        assertNotNull(exception);
+        assertEquals(expectedException.toString(), exception.toString());
+    }
+
+    // endregion
+
+    // region getErrorDescriptionFromBody()
+
+    @Test
+    public void thatGetErrorDescriptionFromBodySucceeds() throws Exception {
+
+        final String field = "error_description";
+        final String expectedDescription = "some arbitrary error description";
+        final String responseBody = String.format("{\"key1\":\"value1\",\"%s\":\"%s\",\"key3\":\"value3\"}", field, expectedDescription);
+
+        String description = errorHandler.getErrorDescriptionFromBody(responseBody);
+
+        assertEquals(expectedDescription, description);
+    }
+
+    @Test
+    public void thatGetErrorDescriptionFromBodyReturnsFallbackMessageForNotFoundField() throws Exception {
+
+        final String field = "someOtherField";
+        final String expectedDescription = "Invalid username or password";
+        final String responseBody = String.format("{\"%s\":\"%s\"}", field, "some arbitrary error description");
+
+        String description = errorHandler.getErrorDescriptionFromBody(responseBody);
+
+        assertEquals(expectedDescription, description);
+    }
+
+    @Test
+    public void thatGetErrorDescriptionFromBodyReturnsFallbackMessageForEmptyBody() throws Exception {
+
+        final String expectedDescription = "Invalid username or password";
+        final String responseBody = "";
+
+        String description = errorHandler.getErrorDescriptionFromBody(responseBody);
+
+        assertEquals(expectedDescription, description);
+    }
+
+    @Test
+    public void thatGetErrorDescriptionFromBodyReturnsFallbackMessageForNonJsonBody() throws Exception {
+
+        final String expectedDescription = "Invalid username or password";
+        final String responseBody = "Non-JSON response body";
+
+        String description = errorHandler.getErrorDescriptionFromBody(responseBody);
+
+        assertEquals(expectedDescription, description);
+    }
+
+    // endregion
+
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
- changes the `RestTemplate` in the `AuthenticationClient` implementation to be a bean, so that it can be managed by Spring and distributed tracing becomes possible.
- also improves exception handling in the `AuthenticationClientDefault`
- cancels the routing if the authentication failed, and returns an error response containing the error description returned by the auth server

```
401 Unauthorized

{
  "message": "Invalid username or password"
}
```
### How is this patch documented?

Code
### How was this patch tested?
- additional unit tests
- manually with Postman
#### Depends On

Nothing.
