### PR TITLE
Change error response to look like response returned by services

### DIFF
--- a/src/main/java/net/smartcosmos/cluster/gateway/domain/ErrorResponse.java
+++ b/src/main/java/net/smartcosmos/cluster/gateway/domain/ErrorResponse.java
@@ -1,0 +1,17 @@
+package net.smartcosmos.cluster.gateway.domain;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ErrorResponse {
+
+    private Long timestamp;
+    private Integer status;
+    private String error;
+    private String message;
+    private String path;
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

The current error response in the gateway looks different than the response in the actual services, so that invalid OAuth tokens and invalid Basic Authentication credentials would result in different responses.

While both of them return _401 Unauthorized_, the message body differs significantly which makes the Postman tests fail at the moment. Expected response is:

```
{
  "timestamp": 1476946891399,
  "status": 401,
  "error": "Unauthorized",
  "message": "Access Denied",
  "path": "/rest/tag/properties"
}
```

The response returned by the gateway is changed to reflect the expected response.
### How is this patch documented?

Code
### How was this patch tested?
- manually using Postman
- existing (updated) and additional unit tests
#### Depends On

Nothing.
