### PR TITLE
Enhancement/evaluate error message timeout

### DIFF
--- a/src/main/java/net/smartcosmos/cluster/gateway/resource/GatewayErrorController.java
+++ b/src/main/java/net/smartcosmos/cluster/gateway/resource/GatewayErrorController.java
@@ -41,6 +41,9 @@ public class GatewayErrorController implements ErrorController {
     public static final String ATTR_SERVICE_ID = "serviceId";
     public static final String ZUUL_REQUEST_URI = "requestURI";
 
+    public static final String ERROR_MESSAGE_GENERAL = "GENERAL";
+    public static final String ERROR_MESSAGE_TIMEOUT = "TIMEOUT";
+
     /**
      * <p>Error handling method that evalutes the current {@link RequestContext} and extracts information on the request, matching routes and error
      * or exceptions that occurred during routing.</p>
@@ -103,7 +106,9 @@ public class GatewayErrorController implements ErrorController {
             log.warn(msg);
             log.debug(msg, errorException, rootCause);
 
-            if (isGatewayTimeout(errorException) || (rootCause != null && isGatewayTimeout(rootCause))) {
+            if (ERROR_MESSAGE_TIMEOUT.equals(errorMessage)
+                || isGatewayTimeout(errorException)
+                || (rootCause != null && isGatewayTimeout(rootCause))) {
                 return errorResponse(GATEWAY_TIMEOUT, exceptionMessage, requestUri);
             }
 

--- a/src/main/java/net/smartcosmos/cluster/gateway/resource/GatewayErrorController.java
+++ b/src/main/java/net/smartcosmos/cluster/gateway/resource/GatewayErrorController.java
@@ -1,6 +1,7 @@
 package net.smartcosmos.cluster.gateway.resource;
 
 import java.net.SocketTimeoutException;
+import java.util.concurrent.TimeoutException;
 
 import com.netflix.client.ClientException;
 import com.netflix.zuul.context.RequestContext;
@@ -150,7 +151,8 @@ public class GatewayErrorController implements ErrorController {
      */
     protected boolean isGatewayTimeout(Throwable throwable) {
 
-        return throwable instanceof SocketTimeoutException;
+        return throwable instanceof SocketTimeoutException
+               || throwable instanceof TimeoutException;
     }
 
     /**

--- a/src/test/java/net/smartcosmos/cluster/gateway/resource/GatewayErrorControllerTest.java
+++ b/src/test/java/net/smartcosmos/cluster/gateway/resource/GatewayErrorControllerTest.java
@@ -2,6 +2,7 @@ package net.smartcosmos.cluster.gateway.resource;
 
 import java.net.SocketTimeoutException;
 import java.util.List;
+import java.util.concurrent.TimeoutException;
 
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
@@ -42,6 +43,7 @@ import static net.smartcosmos.cluster.gateway.resource.GatewayErrorController.AT
 import static net.smartcosmos.cluster.gateway.resource.GatewayErrorController.ATTR_ERROR_STATUS_CODE;
 import static net.smartcosmos.cluster.gateway.resource.GatewayErrorController.ATTR_PROXY;
 import static net.smartcosmos.cluster.gateway.resource.GatewayErrorController.ATTR_SERVICE_ID;
+import static net.smartcosmos.cluster.gateway.resource.GatewayErrorController.ERROR_MESSAGE_TIMEOUT;
 import static net.smartcosmos.cluster.gateway.resource.GatewayErrorController.ZUUL_REQUEST_URI;
 
 @SuppressWarnings("unchecked")
@@ -516,6 +518,21 @@ public class GatewayErrorControllerTest {
         assertEquals(expectedStatus, responseEntity.getStatusCode());
     }
 
+    @Test
+    public void thatThatErrorReturnsGatewayTimeoutInCaseOfTimeoutErrorMessage() {
+
+        final HttpStatus expectedStatus = GATEWAY_TIMEOUT;
+
+        when(requestContext.isEmpty()).thenReturn(false);
+        when(errorController.getErrorMessageFromRequestContext(eq(requestContext))).thenReturn(ERROR_MESSAGE_TIMEOUT);
+        when(errorController.isGatewayTimeout(any())).thenReturn(false);
+        when(errorController.isServiceUnavailable(any())).thenReturn(false);
+
+        ResponseEntity responseEntity = errorController.error();
+
+        assertEquals(expectedStatus, responseEntity.getStatusCode());
+    }
+
     // endregion
 
     // region service unavailable
@@ -681,6 +698,13 @@ public class GatewayErrorControllerTest {
     public void thatIsGatewayTimeoutReturnsTrueForSocketTimeoutException() {
 
         Exception exception = mock(SocketTimeoutException.class);
+        assertTrue(errorController.isGatewayTimeout(exception));
+    }
+
+    @Test
+    public void thatIsGatewayTimeoutReturnsTrueForTimeoutException() {
+
+        Exception exception = mock(TimeoutException.class);
         assertTrue(errorController.isGatewayTimeout(exception));
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Latest Postman collection run resulted in a `java.util.concurrent.TimeoutException: null` exception with error message `TIMEOUT`, caused by a Hystrix timeout.

This was not taken into account for the _504 Gateway Timeout_ response previously.
### How is this patch documented?

Code
### How was this patch tested?

Additional unit tests.
#### Depends On

Nothing.
