### PR TITLE
Allows disabling the filter

### DIFF
--- a/src/main/java/net/smartcosmos/cluster/gateway/filters/PreAuthorizationFilter.java
+++ b/src/main/java/net/smartcosmos/cluster/gateway/filters/PreAuthorizationFilter.java
@@ -16,6 +16,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.netflix.zuul.filters.Route;
 import org.springframework.cloud.netflix.zuul.filters.RouteLocator;
 import org.springframework.http.HttpHeaders;
@@ -46,6 +47,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
  */
 @Slf4j
 @Service
+@ConditionalOnProperty(prefix = "smartcosmos.gateway.pre-authorization-filter", name = "enabled", matchIfMissing = true)
 public class PreAuthorizationFilter extends ZuulFilter {
 
     private static final String FILTER_TYPE_PRE = "pre";


### PR DESCRIPTION
Since the filter does not take into account the server.context-path, when something like: `/rest/oauth/` comes in, it isn't triggered by the `oauth` exclusion, and will attempt to do basic authentication re-write on the JWT requests.