### PR TITLE
bumping hystrix timeout to 300 seconds

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ hystrix:
       execution:
         isolation:
           thread:
-            timeoutInMilliseconds: 60000
+            timeoutInMilliseconds: 300000
     smartcosmos-edge-bulkimport:
       execution:
         isolation:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Testing to see if hystrix.execution.isolation.thread.timeoutInMilliseconds=60000
is the source of the timeouts I'm seeing in the prod-test cluster.

### How is this patch documented?

One value changed in smartcosmos-gateway/src/main/resources/application.yml

### How was this patch tested?

That's what I'm doing now.


#### Depends On

Nothing.
